### PR TITLE
Obsługa pustego $payments

### DIFF
--- a/BillTechPaymentsUpdater.php
+++ b/BillTechPaymentsUpdater.php
@@ -39,7 +39,7 @@ class BillTechPaymentsUpdater
 		$DB->BeginTrans();
 		$payments = $DB->GetAll("SELECT id, customerid, amount, cdate, cashid FROM billtech_payments WHERE closed = 0 AND ?NOW? > cdate + $expiration * 86400");
 
-		if ($this->verbose) {
+		if ($this->verbose && $payments) {
 			echo "Closing " . count($payments) . " expired payments\n";
 		}
 


### PR DESCRIPTION
Usuwa warning w sytuacji, gdy $payments nie zwraca nic:

PHP Warning:  count(): Parameter must be an array or an object that implements Countable in /opt/lms-plus/plugins/BillTech/BillTechPaymentsUpdater.php on line 43