### PR TITLE
Usunięcie problemu z pojawiającym się saldem zamiast linku oraz ukrycie przycisku

### DIFF
--- a/handlers/BillTechLinkInsertHandler.php
+++ b/handlers/BillTechLinkInsertHandler.php
@@ -79,7 +79,7 @@ class BillTechLinkInsertHandler
 		$appendCustomerInfoEnabled = ConfigHelper::getConfig('billtech.append_customer_info', true);
 
         $amount = sprintf('%01.2f', -$hook_data['data']['balance']);
-        $btnPatterns = ['/%billtech_balance_btn/', '/'.$amount.'illtech_balance_btn/'];
+		$btnPatterns = ['/%billtech_balance_btn/', '/'.$amount.'illtech_balance_btn/'];
 
 		if ($hook_data['data']['phone']) {
 			$link = self::getShortPaymentLink('balance', $customerid);
@@ -101,7 +101,6 @@ class BillTechLinkInsertHandler
 
 		return $hook_data;
 	}
-
 
 	public function addButtonToCustomerView(array $hook_data = array())
 	{

--- a/handlers/BillTechLinkInsertHandler.php
+++ b/handlers/BillTechLinkInsertHandler.php
@@ -78,7 +78,7 @@ class BillTechLinkInsertHandler
 		$customerid = $hook_data['data']['id'];
 		$appendCustomerInfoEnabled = ConfigHelper::getConfig('billtech.append_customer_info', true);
 
-        $amount = sprintf('%01.2f', -$hook_data['data']['balance']);
+		$amount = sprintf('%01.2f', -$hook_data['data']['balance']);
 		$btnPatterns = ['/%billtech_balance_btn/', '/'.$amount.'illtech_balance_btn/'];
 
 		if ($hook_data['data']['phone']) {

--- a/handlers/BillTechLinkInsertHandler.php
+++ b/handlers/BillTechLinkInsertHandler.php
@@ -78,21 +78,24 @@ class BillTechLinkInsertHandler
 		$customerid = $hook_data['data']['id'];
 		$appendCustomerInfoEnabled = ConfigHelper::getConfig('billtech.append_customer_info', true);
 
+        $amount = sprintf('%01.2f', -$hook_data['data']['balance']);
+        $btnPatterns = ['/%billtech_balance_btn/', '/'.$amount.'illtech_balance_btn/'];
+
 		if ($hook_data['data']['phone']) {
 			$link = self::getShortPaymentLink('balance', $customerid);
 			if ($appendCustomerInfoEnabled) {
-				$hook_data['body'] = preg_replace('/%billtech_balance_btn/', $link, $hook_data['body']);
+				$hook_data['body'] = preg_replace($btnPatterns, $link, $hook_data['body']);
 			} else {
-				$hook_data['body'] = preg_replace('/%billtech_balance_btn/', '', $hook_data['body']);
+				$hook_data['body'] = preg_replace($btnPatterns, '', $hook_data['body']);
 			}
 		} else {
 			$link = self::getPaymentLink('balance', $customerid, ['utm_medium' => 'email']);
 			if (isset($hook_data['data']['contenttype']) && $hook_data['data']['contenttype'] == 'text/html') {
 				$mail_format = ConfigHelper::getConfig('sendinvoices.mail_format', 'html');
 				$balanceBtnCode = $this->createEmailButton($mail_format, $link);
-				$hook_data['body'] = preg_replace('/%billtech_balance_btn/', $balanceBtnCode, $hook_data['body']);
+				$hook_data['body'] = preg_replace($btnPatterns, $balanceBtnCode, $hook_data['body']);
 			} else {
-				$hook_data['body'] = preg_replace('/%billtech_balance_btn/', $this->createEmailButton('txt', $link), $hook_data['body']);
+				$hook_data['body'] = preg_replace($btnPatterns, $this->createEmailButton('txt', $link), $hook_data['body']);
 			}
 		}
 

--- a/handlers/BillTechLinkInsertHandler.php
+++ b/handlers/BillTechLinkInsertHandler.php
@@ -184,12 +184,12 @@ class BillTechLinkInsertHandler
 
 		if (!ConfigHelper::checkConfig('billtech.balance_button_disabled')) {
 			$balanceLink = $linksManager->getBalanceLink($customerId, ['utm_medium' => 'userpanel'])->link;
-            if($balanceLink != '') {
-                $smarty->assign('billtech_balance_link', $balanceLink);
-                $billtech_balance_button = $smarty->fetch('button' . DIRECTORY_SEPARATOR . $style . DIRECTORY_SEPARATOR . 'billtechbalancebutton.html');
+			if($balanceLink != '') {
+				$smarty->assign('billtech_balance_link', $balanceLink);
+				$billtech_balance_button = $smarty->fetch('button' . DIRECTORY_SEPARATOR . $style . DIRECTORY_SEPARATOR . 'billtechbalancebutton.html');
 
-                $smarty->assign('custom_content', $smarty->getTemplateVars('custom_content') . $billtech_balance_button);
-            }
+				$smarty->assign('custom_content', $smarty->getTemplateVars('custom_content') . $billtech_balance_button);
+			}
 		}
 		return $hook_data;
 	}

--- a/handlers/BillTechLinkInsertHandler.php
+++ b/handlers/BillTechLinkInsertHandler.php
@@ -184,10 +184,12 @@ class BillTechLinkInsertHandler
 
 		if (!ConfigHelper::checkConfig('billtech.balance_button_disabled')) {
 			$balanceLink = $linksManager->getBalanceLink($customerId, ['utm_medium' => 'userpanel'])->link;
-			$smarty->assign('billtech_balance_link', $balanceLink);
-			$billtech_balance_button = $smarty->fetch('button' . DIRECTORY_SEPARATOR . $style . DIRECTORY_SEPARATOR . 'billtechbalancebutton.html');
+            if($balanceLink != '') {
+                $smarty->assign('billtech_balance_link', $balanceLink);
+                $billtech_balance_button = $smarty->fetch('button' . DIRECTORY_SEPARATOR . $style . DIRECTORY_SEPARATOR . 'billtechbalancebutton.html');
 
-			$smarty->assign('custom_content', $smarty->getTemplateVars('custom_content') . $billtech_balance_button);
+                $smarty->assign('custom_content', $smarty->getTemplateVars('custom_content') . $billtech_balance_button);
+            }
 		}
 		return $hook_data;
 	}


### PR DESCRIPTION
1. Problem w wysyłaniu wiadomości wynikał z wykorzystania %b w samym LMSie jako salda, wtedy też BillTech shortcode %billtech_balance_btn nie działał poprawnie.

2. Dodatkowo w userpanelu ukrycie przycisku spłacenia salda, gdy link nie jest dostępny.