### PR TITLE
Handle manually deleted liabilities

### DIFF
--- a/bin/billtech-update-links.php
+++ b/bin/billtech-update-links.php
@@ -161,7 +161,7 @@ $linksManager = new BillTechLinksManager(!$quiet);
 
 BillTech::measureTime(function () use ($linksManager) {
 	BillTech::lock("update-links", function () use ($linksManager) {
-        $linksManager->cancelPaymentLinksIfManuallyDeletedLiability();
+		$linksManager->cancelPaymentLinksIfManuallyDeletedLiability();
 		$linksManager->updateForAll();
 	});
 }, !$quiet);

--- a/bin/billtech-update-links.php
+++ b/bin/billtech-update-links.php
@@ -161,6 +161,7 @@ $linksManager = new BillTechLinksManager(!$quiet);
 
 BillTech::measureTime(function () use ($linksManager) {
 	BillTech::lock("update-links", function () use ($linksManager) {
+        $linksManager->cancelPaymentLinksIfManuallyDeletedLiability();
 		$linksManager->updateForAll();
 	});
 }, !$quiet);

--- a/doc/lms.mysql
+++ b/doc/lms.mysql
@@ -50,8 +50,8 @@ INSERT INTO billtech_info (keytype, keyvalue) VALUES ('current_sync', 0);
 create table billtech_payment_links (
     id serial primary key,
     customer_id integer not null references customers(id) on delete cascade,
-    src_cash_id integer references cash(id) on delete cascade,
-    src_document_id integer references documents(id) on delete cascade,
+    src_cash_id integer references cash(id) on delete set null,
+    src_document_id integer references documents(id) on delete set null,
     type varchar(255) not null,
     link varchar(2000) not null,
     short_link varchar(160),

--- a/doc/lms.pgsql
+++ b/doc/lms.pgsql
@@ -51,8 +51,8 @@ INSERT INTO billtech_info (keytype, keyvalue) VALUES ('current_sync', 0);
 create table billtech_payment_links (
     id serial primary key,
     customer_id integer not null references customers(id) on delete cascade,
-    src_cash_id integer references cash(id) on delete cascade,
-    src_document_id integer references documents(id) on delete cascade,
+    src_cash_id integer references cash(id) on delete set null,
+    src_document_id integer references documents(id) on delete set null,
     type varchar(255) not null,
     link varchar(2000) not null,
     short_link varchar(160),

--- a/lib/BillTechLinksManager.php
+++ b/lib/BillTechLinksManager.php
@@ -19,11 +19,11 @@ class BillTechLinksManager
 	{
 		global $DB;
 		$rows = $DB->GetAll("select bpl.*, c.docid
-                                from billtech_payment_links bpl
-                                         left join cash c on c.id = bpl.src_cash_id
-                                         left join billtech_payments bp on bpl.token = bp.token
-                                where bp.id is null
-                                  and customer_id = ?", array($customerId));
+								from billtech_payment_links bpl
+										 left join cash c on c.id = bpl.src_cash_id
+										 left join billtech_payments bp on bpl.token = bp.token
+								where bp.id is null
+								  and customer_id = ?", array($customerId));
 		if (!is_array($rows)) {
 			return array();
 		}
@@ -213,23 +213,23 @@ class BillTechLinksManager
 		$DB->Execute("delete from billtech_payment_links where id = ?", array($link->id));
 	}
 
-    /**
-     * @return array
-     */
-    private function getPaymentLinksToCancel()
-    {
-        global $DB;
-        return $DB->GetCol("select token from billtech_payment_links where src_cash_id is null and src_document_id is null");
-    }
+	/**
+	 * @return array
+	 */
+	private function getPaymentLinksToCancel()
+	{
+		global $DB;
+		return $DB->GetCol("select token from billtech_payment_links where src_cash_id is null and src_document_id is null");
+	}
 
-    /**
-     * @return array
-     */
-    private function deletePaymentLinkByToken($linkToken)
-    {
-        global $DB;
-        return $DB->GetCol("delete from billtech_payment_links where token = '{$linkToken}'");
-    }
+	/**
+	 * @return array
+	 */
+	private function deletePaymentLinkByToken($linkToken)
+	{
+		global $DB;
+		return $DB->GetCol("delete from billtech_payment_links where token = '{$linkToken}'");
+	}
 
 	private function shouldCancelLink($link)
 	{
@@ -247,14 +247,14 @@ class BillTechLinksManager
 		return $value / 100.0;
 	}
 
-    public function cancelPaymentLinksIfManuallyDeletedLiability() {
-        $paymentLinkTokensToCancel = $this->getPaymentLinksToCancel();
-        foreach($paymentLinkTokensToCancel as $linkToken){
-            BillTechLinkApiService::cancelPaymentLink($linkToken);
-            $this->deletePaymentLinkByToken($linkToken);
-        }
-        echo "Cancelled " . count($paymentLinkTokensToCancel) . " links for manually deleted liability\n";
-    }
+	public function cancelPaymentLinksIfManuallyDeletedLiability() {
+		$paymentLinkTokensToCancel = $this->getPaymentLinksToCancel();
+		foreach($paymentLinkTokensToCancel as $linkToken){
+			BillTechLinkApiService::cancelPaymentLink($linkToken);
+			$this->deletePaymentLinkByToken($linkToken);
+		}
+		echo "Cancelled " . count($paymentLinkTokensToCancel) . " links for manually deleted liability\n";
+	}
 
 	/**
 	 * @param array $actions

--- a/lib/BillTechLinksManager.php
+++ b/lib/BillTechLinksManager.php
@@ -20,8 +20,8 @@ class BillTechLinksManager
 		global $DB;
 		$rows = $DB->GetAll("select bpl.*, c.docid
 				from billtech_payment_links bpl
-						 left join cash c on c.id = bpl.src_cash_id
-						 left join billtech_payments bp on bpl.token = bp.token
+						left join cash c on c.id = bpl.src_cash_id
+						left join billtech_payments bp on bpl.token = bp.token
 				where bp.id is null
 				  and customer_id = ?", array($customerId));
 		if (!is_array($rows)) {

--- a/lib/BillTechLinksManager.php
+++ b/lib/BillTechLinksManager.php
@@ -19,11 +19,11 @@ class BillTechLinksManager
 	{
 		global $DB;
 		$rows = $DB->GetAll("select bpl.*, c.docid
-						from billtech_payment_links bpl
-								 left join cash c on c.id = bpl.src_cash_id
-								 left join billtech_payments bp on bpl.token = bp.token
-						where bp.id is null
-						  and customer_id = ?", array($customerId));
+                from billtech_payment_links bpl
+                         left join cash c on c.id = bpl.src_cash_id
+                         left join billtech_payments bp on bpl.token = bp.token
+                where bp.id is null
+                  and customer_id = ?", array($customerId));
 		if (!is_array($rows)) {
 			return array();
 		}

--- a/lib/BillTechLinksManager.php
+++ b/lib/BillTechLinksManager.php
@@ -19,11 +19,11 @@ class BillTechLinksManager
 	{
 		global $DB;
 		$rows = $DB->GetAll("select bpl.*, c.docid
-            from billtech_payment_links bpl
-                     left join cash c on c.id = bpl.src_cash_id
-                     left join billtech_payments bp on bpl.token = bp.token
-            where bp.id is null
-              and customer_id = ?", array($customerId));
+						from billtech_payment_links bpl
+								 left join cash c on c.id = bpl.src_cash_id
+								 left join billtech_payments bp on bpl.token = bp.token
+						where bp.id is null
+						  and customer_id = ?", array($customerId));
 		if (!is_array($rows)) {
 			return array();
 		}

--- a/lib/BillTechLinksManager.php
+++ b/lib/BillTechLinksManager.php
@@ -19,11 +19,11 @@ class BillTechLinksManager
 	{
 		global $DB;
 		$rows = $DB->GetAll("select bpl.*, c.docid
-								from billtech_payment_links bpl
-										 left join cash c on c.id = bpl.src_cash_id
-										 left join billtech_payments bp on bpl.token = bp.token
-								where bp.id is null
-								  and customer_id = ?", array($customerId));
+						from billtech_payment_links bpl
+								 left join cash c on c.id = bpl.src_cash_id
+								 left join billtech_payments bp on bpl.token = bp.token
+						where bp.id is null
+						  and customer_id = ?", array($customerId));
 		if (!is_array($rows)) {
 			return array();
 		}
@@ -223,12 +223,12 @@ class BillTechLinksManager
 	}
 
 	/**
-	 * @return array
+	 * @var $linkToken String
 	 */
 	private function deletePaymentLinkByToken($linkToken)
 	{
 		global $DB;
-		return $DB->GetCol("delete from billtech_payment_links where token = '{$linkToken}'");
+        $DB->Execute("delete from billtech_payment_links where token = ?", array($linkToken));
 	}
 
 	private function shouldCancelLink($link)

--- a/lib/BillTechLinksManager.php
+++ b/lib/BillTechLinksManager.php
@@ -19,11 +19,11 @@ class BillTechLinksManager
 	{
 		global $DB;
 		$rows = $DB->GetAll("select bpl.*, c.docid
-                from billtech_payment_links bpl
-                         left join cash c on c.id = bpl.src_cash_id
-                         left join billtech_payments bp on bpl.token = bp.token
-                where bp.id is null
-                  and customer_id = ?", array($customerId));
+				from billtech_payment_links bpl
+						 left join cash c on c.id = bpl.src_cash_id
+						 left join billtech_payments bp on bpl.token = bp.token
+				where bp.id is null
+				  and customer_id = ?", array($customerId));
 		if (!is_array($rows)) {
 			return array();
 		}
@@ -228,7 +228,7 @@ class BillTechLinksManager
 	private function deletePaymentLinkByToken($linkToken)
 	{
 		global $DB;
-        $DB->Execute("delete from billtech_payment_links where token = ?", array($linkToken));
+		$DB->Execute("delete from billtech_payment_links where token = ?", array($linkToken));
 	}
 
 	private function shouldCancelLink($link)

--- a/lib/BillTechLinksManager.php
+++ b/lib/BillTechLinksManager.php
@@ -19,11 +19,11 @@ class BillTechLinksManager
 	{
 		global $DB;
 		$rows = $DB->GetAll("select bpl.*, c.docid
-						from billtech_payment_links bpl
-								 left join cash c on c.id = bpl.src_cash_id
-								 left join billtech_payments bp on bpl.token = bp.token
-						where bp.id is null
-						  and customer_id = ?", array($customerId));
+            from billtech_payment_links bpl
+                     left join cash c on c.id = bpl.src_cash_id
+                     left join billtech_payments bp on bpl.token = bp.token
+            where bp.id is null
+              and customer_id = ?", array($customerId));
 		if (!is_array($rows)) {
 			return array();
 		}

--- a/lib/BillTechLinksManager.php
+++ b/lib/BillTechLinksManager.php
@@ -20,8 +20,8 @@ class BillTechLinksManager
 		global $DB;
 		$rows = $DB->GetAll("select bpl.*, c.docid
 				from billtech_payment_links bpl
-						left join cash c on c.id = bpl.src_cash_id
-						left join billtech_payments bp on bpl.token = bp.token
+					left join cash c on c.id = bpl.src_cash_id
+					left join billtech_payments bp on bpl.token = bp.token
 				where bp.id is null
 				  and customer_id = ?", array($customerId));
 		if (!is_array($rows)) {

--- a/lib/upgradedb/mysql.2022011200.php
+++ b/lib/upgradedb/mysql.2022011200.php
@@ -1,0 +1,18 @@
+<?php
+$this->Execute("
+ALTER TABLE billtech_payment_links
+DROP FOREIGN KEY billtech_payment_links_src_cash_id_fkey,
+                ADD CONSTRAINT billtech_payment_links_src_cash_id_fkey
+FOREIGN KEY (src_cash_id) REFERENCES cash ON
+DELETE
+SET NULL
+");
+
+$this->Execute("
+ALTER TABLE billtech_payment_links
+DROP FOREIGN KEY billtech_payment_links_src_document_id_fkey,
+                ADD CONSTRAINT billtech_payment_links_src_document_id_fkey
+FOREIGN KEY (src_document_id) REFERENCES documents ON
+DELETE
+SET NULL
+");

--- a/lib/upgradedb/postgres.2022011200.php
+++ b/lib/upgradedb/postgres.2022011200.php
@@ -1,0 +1,18 @@
+<?php
+$this->Execute("
+ALTER TABLE billtech_payment_links
+DROP CONSTRAINT billtech_payment_links_src_cash_id_fkey,
+                ADD CONSTRAINT billtech_payment_links_src_cash_id_fkey
+FOREIGN KEY (src_cash_id) REFERENCES cash ON
+DELETE
+SET NULL
+");
+
+$this->Execute("
+ALTER TABLE billtech_payment_links
+DROP CONSTRAINT billtech_payment_links_src_document_id_fkey,
+                ADD CONSTRAINT billtech_payment_links_src_document_id_fkey
+FOREIGN KEY (src_document_id) REFERENCES documents ON
+DELETE
+SET NULL
+");


### PR DESCRIPTION
Obsługa przypadku, w którym usunięte zostają faktury bezpośrednio z bazy danych (z tabel cash oraz documents). W tym przypadku wygenerowane linki mają zamiast kluczy NULL, co jest detekowane podczas zadania CRON generującego linki. Jeśli jakikolwiek link z tabeli ma billtech_payment_links cash_id i document_id jako NULL, wtedy dany link jest CANCEL'owany w BT API a następnie usuwany z tabeli billtech_payment_links.
