### PR TITLE
Clear logs older than 31 days in cron

### DIFF
--- a/bin/billtech-clear-logs.php
+++ b/bin/billtech-clear-logs.php
@@ -1,0 +1,9 @@
+<?php
+    $logDirectory = '/var/log/billtech/';
+
+    $fileSystemIterator = new FilesystemIterator($logDirectory);
+    foreach ($fileSystemIterator as $file) {
+        if (time() - $file->getCTime() >= 60*60*24*31){
+            unlink($logDirectory.$file->getFilename());
+        }
+    }

--- a/cron/billtech-update-clear-logs-cron
+++ b/cron/billtech-update-clear-logs-cron
@@ -1,0 +1,1 @@
+0 0 1 * * bash -c ${sys_dir}/plugins/BillTech/bin/billtech-clear-logs.php


### PR DESCRIPTION
Nowy CRONTAB odpalany zawsze 1 dnia miesiąca, wywołuje nowy skrypt billtech-clear-logs.php, który usuwa ze standardowej ścieżki z logami pliki starsze niż 31 dni. Ścieżka raczej nie jest zmieniana przez użytkowników, bo też jest na sztywno w crontabie.