### PR TITLE
Update BillTechLinksManager.php

### DIFF
--- a/lib/BillTechLinksManager.php
+++ b/lib/BillTechLinksManager.php
@@ -248,7 +248,7 @@ class BillTechLinksManager
 	}
 
 	public function cancelPaymentLinksIfManuallyDeletedLiability() {
-		$paymentLinkTokensToCancel = $this->getPaymentLinksToCancel();
+		$paymentLinkTokensToCancel = $this->getPaymentLinksToCancel() ? $this->getPaymentLinksToCancel() : array();
 		foreach($paymentLinkTokensToCancel as $linkToken){
 			BillTechLinkApiService::cancelPaymentLink($linkToken);
 			$this->deletePaymentLinkByToken($linkToken);

--- a/lib/BillTechLinksManager.php
+++ b/lib/BillTechLinksManager.php
@@ -248,7 +248,7 @@ class BillTechLinksManager
 	}
 
 	public function cancelPaymentLinksIfManuallyDeletedLiability() {
-		$paymentLinkTokensToCancel = $this->getPaymentLinksToCancel() ? $this->getPaymentLinksToCancel() : array();
+		$paymentLinkTokensToCancel = $this->getPaymentLinksToCancel() ?: array();
 		foreach($paymentLinkTokensToCancel as $linkToken){
 			BillTechLinkApiService::cancelPaymentLink($linkToken);
 			$this->deletePaymentLinkByToken($linkToken);


### PR DESCRIPTION
Wyciszanie błędu kiedy `$this->getPaymentLinksToCancel()` nic nie zwraca.
Dotyczy #73 