### PR TITLE
Return array if null

### DIFF
--- a/lib/BillTechLinksManager.php
+++ b/lib/BillTechLinksManager.php
@@ -219,7 +219,7 @@ class BillTechLinksManager
 	private function getPaymentLinksToCancel()
 	{
 		global $DB;
-		return $DB->GetCol("select token from billtech_payment_links where src_cash_id is null and src_document_id is null");
+		return $DB->GetCol("select token from billtech_payment_links where src_cash_id is null and src_document_id is null")?: array();
 	}
 
 	/**


### PR DESCRIPTION
Uniknięcie warningów w logach, gdy null zwracany przez metodę z bazy danych.