### PR TITLE
Poprawki dotyczące pobierania numeru konta

### DIFF
--- a/handlers/BillTechLinkInsertHandler.php
+++ b/handlers/BillTechLinkInsertHandler.php
@@ -207,7 +207,7 @@ class BillTechLinkInsertHandler
 			'customerid' => $doc['customerid'],
 		));
 
-		$nrb = bankaccount($doc_content['customerid'], $doc_content['account']);
+        $nrb = iban_account('PL',26, $doc_content['customerid'], $doc_content['account']);
 
 		if ($nrb == "" && !empty($doc_content['bankaccounts'])) {
 			$nrb = $doc_content['bankaccounts'][0];

--- a/handlers/BillTechLinkInsertHandler.php
+++ b/handlers/BillTechLinkInsertHandler.php
@@ -207,7 +207,7 @@ class BillTechLinkInsertHandler
 			'customerid' => $doc['customerid'],
 		));
 
-		$nrb = iban_account('PL',26, $doc_content['customerid'], $doc_content['account']);
+		$nrb = iban_account('PL', 26, $doc_content['customerid'], $doc_content['account']);
 
 		if ($nrb == "" && !empty($doc_content['bankaccounts'])) {
 			$nrb = $doc_content['bankaccounts'][0];

--- a/handlers/BillTechLinkInsertHandler.php
+++ b/handlers/BillTechLinkInsertHandler.php
@@ -207,7 +207,7 @@ class BillTechLinkInsertHandler
 			'customerid' => $doc['customerid'],
 		));
 
-        $nrb = iban_account('PL',26, $doc_content['customerid'], $doc_content['account']);
+		$nrb = iban_account('PL',26, $doc_content['customerid'], $doc_content['account']);
 
 		if ($nrb == "" && !empty($doc_content['bankaccounts'])) {
 			$nrb = $doc_content['bankaccounts'][0];

--- a/lib/BillTechLinkApiService.php
+++ b/lib/BillTechLinkApiService.php
@@ -158,9 +158,14 @@ class BillTechLinkApiService
 	{
 		global $DB;
 
-		$alternativeBankAccounts =
-			$DB->GetAll('SELECT contact FROM customercontacts WHERE customerid = ? AND  (type & ?) = ?',
-				array($customerId, (CONTACT_BANKACCOUNT | CONTACT_INVOICES | CONTACT_DISABLED), (CONTACT_BANKACCOUNT | CONTACT_INVOICES)));
+		$alternativeBankAccounts = $DB->GetAll(
+                'SELECT contact FROM customercontacts WHERE customerid = ? AND  (type & ?) = ?',
+				array(
+                    $customerId,
+                    (CONTACT_BANKACCOUNT | CONTACT_INVOICES | CONTACT_DISABLED),
+                    (CONTACT_BANKACCOUNT | CONTACT_INVOICES)
+                )
+            );
 
 		if (!empty($alternativeBankAccounts)) {
 			return iban_account('PL',26, $customerId, $alternativeBankAccounts[0]['contact']);

--- a/lib/BillTechLinkApiService.php
+++ b/lib/BillTechLinkApiService.php
@@ -159,8 +159,7 @@ class BillTechLinkApiService
 		global $DB;
 
 		$alternativeBankAccounts =
-			$DB->GetAll('SELECT contact FROM customercontacts
-								WHERE customerid = ? AND  (type & ?) = ?',
+			$DB->GetAll('SELECT contact FROM customercontacts WHERE customerid = ? AND  (type & ?) = ?',
 				array($customerId, (CONTACT_BANKACCOUNT | CONTACT_INVOICES | CONTACT_DISABLED), (CONTACT_BANKACCOUNT | CONTACT_INVOICES)));
 
 		if (!empty($alternativeBankAccounts)) {

--- a/lib/BillTechLinkApiService.php
+++ b/lib/BillTechLinkApiService.php
@@ -99,9 +99,8 @@ class BillTechLinkApiService
 		global $DB;
 
 		if ($linkRequest->srcDocumentId) {
-			// TODO: use customercontacts for email
 			$linkData = $DB->GetRow("select" . ($DB->GetDbType() == "postgres" ? " distinct on (c.id)" : "") .
-				" d.customerid, d.number, d.fullnumber, d.comment, d.div_account, d.id, d.name as fullname, c.lastname,
+				" d.customerid, d.number, d.fullnumber, d.comment, COALESCE(NULLIF(d.div_account,''), di.account) as div_account, d.id, d.name as fullname, c.lastname,
 				 c.name, d.cdate, d.paytime, di.id as division_id, di.shortname as division_name, cc.contact as email 
 				 						from documents d
     									left join customers c on d.customerid = c.id
@@ -150,6 +149,27 @@ class BillTechLinkApiService
 		throw new Exception($message);
 	}
 
+    /**
+     * @param $customerId
+     * @param $divisionBankAccount
+     * @return string
+     */
+    private static function getBankAccount($customerId, $divisionBankAccount)
+    {
+        global $DB;
+
+        $alternativeBankAccounts =
+            $DB->GetAll('SELECT contact FROM customercontacts
+                                WHERE customerid = ? AND  (type & ?) = ?',
+                array($customerId, (CONTACT_BANKACCOUNT | CONTACT_INVOICES | CONTACT_DISABLED), (CONTACT_BANKACCOUNT | CONTACT_INVOICES)));
+
+        if (!empty($alternativeBankAccounts)) {
+            return iban_account('PL',26, $customerId, $alternativeBankAccounts[0]['contact']);
+        }
+
+        return iban_account('PL',26, $customerId, $divisionBankAccount);
+    }
+
 	/**
 	 * @param $linkData
 	 * @return array
@@ -161,7 +181,7 @@ class BillTechLinkApiService
 			'userId' => $linkData['customerid'],
 			'operationId' => $linkData['key'],
 			'amount' => $linkData['amount'],
-			'nrb' => ConfigHelper::getConfig('billtech.bankaccount', bankaccount($linkData['customerid'], $linkData['div_account'])),
+			'nrb' => ConfigHelper::getConfig('billtech.bankaccount', self::getBankAccount($linkData['customerid'], $linkData['div_account'])),
 			'paymentDue' => (new DateTime('@' . ($linkData['pdate'] ?: time())))->format('Y-m-d'),
 			'title' => self::getTitle($linkData['title'])
 		);

--- a/lib/BillTechLinkApiService.php
+++ b/lib/BillTechLinkApiService.php
@@ -168,10 +168,10 @@ class BillTechLinkApiService
 		);
 
 		if (!empty($alternativeBankAccounts)) {
-			return iban_account('PL',26, $customerId, $alternativeBankAccounts[0]['contact']);
+			return iban_account('PL', 26, $customerId, $alternativeBankAccounts[0]['contact']);
 		}
 
-		return iban_account('PL',26, $customerId, $divisionBankAccount);
+		return iban_account('PL', 26, $customerId, $divisionBankAccount);
 	}
 
 	/**

--- a/lib/BillTechLinkApiService.php
+++ b/lib/BillTechLinkApiService.php
@@ -159,13 +159,13 @@ class BillTechLinkApiService
 		global $DB;
 
 		$alternativeBankAccounts = $DB->GetAll(
-                'SELECT contact FROM customercontacts WHERE customerid = ? AND  (type & ?) = ?',
-				array(
-                    $customerId,
-                    (CONTACT_BANKACCOUNT | CONTACT_INVOICES | CONTACT_DISABLED),
-                    (CONTACT_BANKACCOUNT | CONTACT_INVOICES)
-                )
-            );
+			'SELECT contact FROM customercontacts WHERE customerid = ? AND  (type & ?) = ?',
+			array(
+				$customerId,
+				(CONTACT_BANKACCOUNT | CONTACT_INVOICES | CONTACT_DISABLED),
+				(CONTACT_BANKACCOUNT | CONTACT_INVOICES)
+			)
+		);
 
 		if (!empty($alternativeBankAccounts)) {
 			return iban_account('PL',26, $customerId, $alternativeBankAccounts[0]['contact']);

--- a/lib/BillTechLinkApiService.php
+++ b/lib/BillTechLinkApiService.php
@@ -159,7 +159,7 @@ class BillTechLinkApiService
 		global $DB;
 
 		$alternativeBankAccounts = $DB->GetAll(
-			'SELECT contact FROM customercontacts WHERE customerid = ? AND  (type & ?) = ?',
+			'SELECT contact FROM customercontacts WHERE customerid = ? AND (type & ?) = ?',
 			array(
 				$customerId,
 				(CONTACT_BANKACCOUNT | CONTACT_INVOICES | CONTACT_DISABLED),

--- a/lib/BillTechLinkApiService.php
+++ b/lib/BillTechLinkApiService.php
@@ -102,9 +102,9 @@ class BillTechLinkApiService
 			$linkData = $DB->GetRow("select" . ($DB->GetDbType() == "postgres" ? " distinct on (c.id)" : "") .
 				" d.customerid, d.number, d.fullnumber, d.comment, COALESCE(NULLIF(d.div_account,''), di.account) as div_account, d.id, d.name as fullname, c.lastname,
 				 c.name, d.cdate, d.paytime, di.id as division_id, di.shortname as division_name, cc.contact as email 
-				 						from documents d
-    									left join customers c on d.customerid = c.id
-       									left join customercontacts cc on cc.customerid = c.id and (cc.type & 8) > 1
+										from documents d
+										left join customers c on d.customerid = c.id
+										left join customercontacts cc on cc.customerid = c.id and (cc.type & 8) > 1
 										left join divisions di on c.divisionid = di.id where d.id = ?" . ($DB->GetDbType() == "mysql" ? " group by c.id" : ""), [$linkRequest->srcDocumentId]);
 			if (!$linkData) {
 				throw new Exception("Could not fetch link data by document id: " . $linkRequest->srcDocumentId);
@@ -114,7 +114,7 @@ class BillTechLinkApiService
 			$linkData = $DB->GetRow("select" . ($DB->GetDbType() == "postgres" ? " distinct on (cu.id)" : "") .
 				" ca.customerid, ca.docid, cu.lastname, cu.name, d.cdate, d.paytime, ca.comment as title, di.id as division_id, di.shortname as division_name, cc.contact as email, di.account as div_account from cash ca
 										left join customers cu on ca.customerid = cu.id 
-       									left join customercontacts cc on cc.customerid = cu.id and (cc.type & 8) > 1
+										left join customercontacts cc on cc.customerid = cu.id and (cc.type & 8) > 1
 										left join documents d on d.id = ca.docid
 										left join divisions di on cu.divisionid = di.id 
 										where ca.id = ?" . ($DB->GetDbType() == "mysql" ? " group by cu.id" : ""), [$linkRequest->srcCashId]);
@@ -149,26 +149,26 @@ class BillTechLinkApiService
 		throw new Exception($message);
 	}
 
-    /**
-     * @param $customerId
-     * @param $divisionBankAccount
-     * @return string
-     */
-    private static function getBankAccount($customerId, $divisionBankAccount)
-    {
-        global $DB;
+	/**
+	 * @param $customerId
+	 * @param $divisionBankAccount
+	 * @return string
+	 */
+	private static function getBankAccount($customerId, $divisionBankAccount)
+	{
+		global $DB;
 
-        $alternativeBankAccounts =
-            $DB->GetAll('SELECT contact FROM customercontacts
-                                WHERE customerid = ? AND  (type & ?) = ?',
-                array($customerId, (CONTACT_BANKACCOUNT | CONTACT_INVOICES | CONTACT_DISABLED), (CONTACT_BANKACCOUNT | CONTACT_INVOICES)));
+		$alternativeBankAccounts =
+			$DB->GetAll('SELECT contact FROM customercontacts
+								WHERE customerid = ? AND  (type & ?) = ?',
+				array($customerId, (CONTACT_BANKACCOUNT | CONTACT_INVOICES | CONTACT_DISABLED), (CONTACT_BANKACCOUNT | CONTACT_INVOICES)));
 
-        if (!empty($alternativeBankAccounts)) {
-            return iban_account('PL',26, $customerId, $alternativeBankAccounts[0]['contact']);
-        }
+		if (!empty($alternativeBankAccounts)) {
+			return iban_account('PL',26, $customerId, $alternativeBankAccounts[0]['contact']);
+		}
 
-        return iban_account('PL',26, $customerId, $divisionBankAccount);
-    }
+		return iban_account('PL',26, $customerId, $divisionBankAccount);
+	}
 
 	/**
 	 * @param $linkData


### PR DESCRIPTION
- Pobieranie alternatywnego numeru konta w pierwszej kolejności, jeśli jest odhaczone przy nim pole "Faktury" oraz nie jest on wyłączony. W przypadku większej liczby aktywnych numerów alternatywnych pobierany jest pierwszy z listy.
- W przypadku braku numeru konta dla dokumentu, co miało miejsce czasami np. dla not odsetkowych numer konta pobierany jest dodatkowo z tabeli oddziałów/divisions
- Uniezależnienie się od języka systemu, gdzie funkcja bankaccount była od niego uzależniona i skorzystanie z metody iban_account oraz forsowanie języka polskiego - nie obsługujemy płatności zagranicznych.