### PR TITLE
Extend payment search time to 1 hour

### DIFF
--- a/BillTechPaymentsUpdater.php
+++ b/BillTechPaymentsUpdater.php
@@ -76,7 +76,7 @@ class BillTechPaymentsUpdater
 		$last_sync = $this->getLastSync();
 
 		$client = BillTechApiClientFactory::getClient();
-		$path = "/pay/v1/payments/search" . "?fromDate=" . (ConfigHelper::checkConfig("billtech.debug") ? 0 : ($last_sync - 86400));
+		$path = "/pay/v1/payments/search" . "?fromDate=" . (ConfigHelper::checkConfig("billtech.debug") ? 0 : ($last_sync - 3600));
 
 		$response = $client->get($path);
 

--- a/BillTechPaymentsUpdater.php
+++ b/BillTechPaymentsUpdater.php
@@ -76,7 +76,7 @@ class BillTechPaymentsUpdater
 		$last_sync = $this->getLastSync();
 
 		$client = BillTechApiClientFactory::getClient();
-		$path = "/pay/v1/payments/search" . "?fromDate=" . (ConfigHelper::checkConfig("billtech.debug") ? 0 : ($last_sync - 60));
+		$path = "/pay/v1/payments/search" . "?fromDate=" . (ConfigHelper::checkConfig("billtech.debug") ? 0 : ($last_sync - 86400));
 
 		$response = $client->get($path);
 


### PR DESCRIPTION
Rozszerzenie w przypadku gdy pobieranie płatności trwa dłużej niż minuta, w takim przypadku mogły nie pobierać się informacje dotyczące nowych płatności. Rozszerzenie czasu do 1 godziny z dużym zapasem.