### PR TITLE
Zmiana wartości last_cash_id dla billtech_customer_info

### DIFF
--- a/lib/BillTechLinksManager.php
+++ b/lib/BillTechLinksManager.php
@@ -68,7 +68,6 @@ class BillTechLinksManager
 
 	public function updateForAll()
 	{
-		global $DB;
 		$actions = array(
 			'add' => array(),
 			'update' => array(),
@@ -85,8 +84,6 @@ class BillTechLinksManager
 			return;
 		}
 
-		$maxCashId = $DB->GetOne("select max(id) from cash");
-
 		foreach ($customerIds as $idx => $customerId) {
 			echo "Collecting actions for customer " . ($idx + 1) . " of " . count($customerIds) . "\n";
 			$actions = array_merge_recursive($actions, $this->getCustomerUpdateBalanceActions($customerId));
@@ -99,8 +96,14 @@ class BillTechLinksManager
 		}
 
 		if ($this->performActions($actions)) {
-			$this->updateCustomerInfos($customerIds, $maxCashId);
+			$this->updateCustomerInfos($customerIds);
 		}
+	}
+
+	private function checkIfCustomerCashIdExists($customerId, $cashId)
+	{
+		global $DB;
+		return $DB->GetOne('select count(*) from cash where customerid = ? and id = ?', array($customerId, $cashId));
 	}
 
 	public function updateCustomerBalance($customerId)
@@ -113,7 +116,7 @@ class BillTechLinksManager
 										where bci.customer_id = ?
 										group by bci.customer_id", array($customerId));
 
-		if ($customerInfo['new_last_cash_id'] > $customerInfo['last_cash_id']) {
+		if ($customerInfo['new_last_cash_id'] > $customerInfo['last_cash_id'] || ($customerInfo['new_last_cash_id'] < $customerInfo['last_cash_id'] && !$this->checkIfCustomerCashIdExists($customerId, $customerInfo['last_cash_id']))) {
 			$actions = $this->getCustomerUpdateBalanceActions($customerId);
 			if ($this->performActions($actions)) {
 				$DB->Execute("update billtech_customer_info set last_cash_id = ? where customer_id = ?", array($customerInfo['new_last_cash_id'], $customerId));
@@ -410,19 +413,18 @@ class BillTechLinksManager
 												 left join billtech_customer_info bci on bci.customer_id = cu.id
 												 left join cash ca on ca.customerid = cu.id
 										group by bci.customer_id, bci.last_cash_id
-										having bci.last_cash_id <= coalesce(max(ca.id), 0);");
+										having bci.last_cash_id != coalesce(max(ca.id), 0);")?: array();
 	}
 
 	/**
 	 * @param array $customerIds
-	 * @param $maxCashId
 	 */
-	private function updateCustomerInfos(array $customerIds, $maxCashId)
+	private function updateCustomerInfos(array $customerIds)
 	{
 		global $DB;
-		$params = $customerIds;
-		array_unshift($params, $maxCashId);
-		$DB->Execute("update billtech_customer_info set last_cash_id = ? where customer_id in (" . BillTech::repeatWithSeparator("?", ",", count($customerIds)) . ")", $params);
+		$DB->Execute("update billtech_customer_info bci
+							set last_cash_id = (select max(c.id) from cash c where c.customerid = bci.customer_id)
+							where customer_id in (".implode(',', $customerIds).");");
 	}
 
 	/**

--- a/lib/BillTechLinksManager.php
+++ b/lib/BillTechLinksManager.php
@@ -100,13 +100,21 @@ class BillTechLinksManager
 		}
 	}
 
-	private function checkIfCustomerCashIdExists($customerId, $cashId)
-	{
+    /**
+     * @param $customerId integer
+     * @param $cashId integer
+     * @return bool
+     */
+	private function checkIfCustomerCashIdExists(integer $customerId, integer $cashId): bool
+    {
 		global $DB;
 		return $DB->GetOne('select count(*) from cash where customerid = ? and id = ?', array($customerId, $cashId));
 	}
 
-	public function updateCustomerBalance($customerId)
+    /**
+     * @var $customerId integer
+     */
+	public function updateCustomerBalance(integer $customerId)
 	{
 		global $DB;
 		$this->addMissingCustomerInfo();
@@ -423,8 +431,8 @@ class BillTechLinksManager
 	{
 		global $DB;
 		$DB->Execute("update billtech_customer_info bci
-							set last_cash_id = (select max(c.id) from cash c where c.customerid = bci.customer_id)
-							where customer_id in (".implode(',', $customerIds).");");
+		set last_cash_id = (select max(c.id) from cash c where c.customerid = bci.customer_id)
+		where customer_id in (".implode(',', $customerIds).");");
 	}
 
 	/**


### PR DESCRIPTION
Aktualnie w tabeli billtech_customer_info przetrzymujemy pary customer_id | last_cash_id. Niestety ten last_cash_id nie odpowiada realnie rekordowi cash danego użytkownika, tylko najwyższego id na całej tabeli cash w momencie wykonania ostatniej aktualizacji.
Ułatwi to trakowanie aktualizacji u danego usera, bo będzie jasno widać, który cash był ostatni aktualizowany przez wtyczkę i dodatkowo w przypadku ręcznych usuwań (na przykład faktura jest opłacona, ale rekord wpłaty zostaje jednak usunięty ręcznie przez dostawcę) wracamy z cash_id do poprzedniej faktury i dokonujemy przeliczenia (bo wykrywane jest i przeliczany jest bilans).