### PR TITLE
Aktualizacja nazw stałych i dodanie nowych do aktualnego szablonu wtyczki

### DIFF
--- a/BillTech.php
+++ b/BillTech.php
@@ -31,12 +31,15 @@
  */
 class BillTech extends LMSPlugin
 {
-	const PLUGIN_DBVERSION = 2022012000;
+    const PLUGIN_DBVERSION = 2022012000; /* Legacy for old LMS versions */
+    const PLUGIN_DB_VERSION = 2022012000;
+    const PLUGIN_SOFTWARE_VERSION = 2022012000;
 	const PLUGIN_DIRECTORY_NAME = 'BillTech';
 	const PLUGIN_NAME = 'BillTech';
 	const PLUGIN_DESCRIPTION = 'BillTech - wersja: 20220120';
 	const PLUGIN_AUTHOR = 'Michał Kaciuba &lt;michal@billtech.pl&gt;';
 	const CASH_COMMENT = 'Wpłata online';
+    const PLUGIN_REPO_URL = 'https://github.com/BillTechPL/lms-billtech-plugin';
 
 	public function registerHandlers()
 	{

--- a/BillTech.php
+++ b/BillTech.php
@@ -32,7 +32,7 @@
 class BillTech extends LMSPlugin
 {
 	const PLUGIN_DB_VERSION = 2022012000;
-    const PLUGIN_DBVERSION = PLUGIN_DB_VERSION; /* Legacy for old LMS versions */
+	const PLUGIN_DBVERSION = PLUGIN_DB_VERSION; /* Legacy for old LMS versions */
 	const PLUGIN_SOFTWARE_VERSION = 2022012000;
 	const PLUGIN_DIRECTORY_NAME = 'BillTech';
 	const PLUGIN_NAME = 'BillTech';

--- a/BillTech.php
+++ b/BillTech.php
@@ -31,15 +31,15 @@
  */
 class BillTech extends LMSPlugin
 {
-    const PLUGIN_DBVERSION = 2022012000; /* Legacy for old LMS versions */
-    const PLUGIN_DB_VERSION = 2022012000;
-    const PLUGIN_SOFTWARE_VERSION = 2022012000;
+	const PLUGIN_DBVERSION = 2022012000; /* Legacy for old LMS versions */
+	const PLUGIN_DB_VERSION = 2022012000;
+	const PLUGIN_SOFTWARE_VERSION = 2022012000;
 	const PLUGIN_DIRECTORY_NAME = 'BillTech';
 	const PLUGIN_NAME = 'BillTech';
 	const PLUGIN_DESCRIPTION = 'BillTech - wersja: 20220120';
 	const PLUGIN_AUTHOR = 'Michał Kaciuba &lt;michal@billtech.pl&gt;';
 	const CASH_COMMENT = 'Wpłata online';
-    const PLUGIN_REPO_URL = 'https://github.com/BillTechPL/lms-billtech-plugin';
+	const PLUGIN_REPO_URL = 'https://github.com/BillTechPL/lms-billtech-plugin';
 
 	public function registerHandlers()
 	{

--- a/BillTech.php
+++ b/BillTech.php
@@ -31,8 +31,8 @@
  */
 class BillTech extends LMSPlugin
 {
-	const PLUGIN_DBVERSION = 2022012000; /* Legacy for old LMS versions */
 	const PLUGIN_DB_VERSION = 2022012000;
+    const PLUGIN_DBVERSION = PLUGIN_DB_VERSION; /* Legacy for old LMS versions */
 	const PLUGIN_SOFTWARE_VERSION = 2022012000;
 	const PLUGIN_DIRECTORY_NAME = 'BillTech';
 	const PLUGIN_NAME = 'BillTech';


### PR DESCRIPTION
Niestety potrzebny będzie duplikat tego const'a ze wzgledu na wsteczną kompatybilność.
https://github.com/chilek/lms/search?q=PLUGIN_DB_VERSION

Dodałem też dwa nowe const'y (software version i repo url), które też doszły, a przy okazji mogą w przyszłości być wykorzystane przy systemie automatycznej aktualizacji.