### PR TITLE
Cron lock per database

### DIFF
--- a/bin/billtech-update-links.php
+++ b/bin/billtech-update-links.php
@@ -159,8 +159,8 @@ $LMS->setPluginManager($plugin_manager);
 
 $linksManager = new BillTechLinksManager(!$quiet);
 
-BillTech::measureTime(function () use ($linksManager) {
-	BillTech::lock("update-links", function () use ($linksManager) {
+BillTech::measureTime(function () use ($linksManager, $CONFIG) {
+	BillTech::lock("update-links-".$CONFIG['database']['database'], function () use ($linksManager) {
 		$linksManager->cancelPaymentLinksIfManuallyDeletedLiability();
 		$linksManager->updateForAll();
 	});

--- a/bin/billtech-update-payments.php
+++ b/bin/billtech-update-payments.php
@@ -163,8 +163,8 @@ $LMS->setPluginManager($plugin_manager);
 
 $paymentsUpdater = new BillTechPaymentsUpdater(!$quiet);
 
-BillTech::measureTime(function () use ($paymentsUpdater) {
-	BillTech::lock("update-payments", function () use ($paymentsUpdater) {
+BillTech::measureTime(function () use ($paymentsUpdater, $CONFIG) {
+	BillTech::lock("update-payments-".$CONFIG['database']['database'], function () use ($paymentsUpdater) {
 		$paymentsUpdater->checkForUpdate();
 	});
 }, !$quiet);


### PR DESCRIPTION
Blokada cronów z nazwą bazy, tak żeby dwie instancje LMSa obok siebie z tą samą bazą plików, ale różnymi plikami konfiguracyjnymi lms.ini nie blokowały siebie nawzajem.