### PR TITLE
Bugfix/catch guzzle post errors

### DIFF
--- a/lib/LinkShortenerApiService.php
+++ b/lib/LinkShortenerApiService.php
@@ -22,9 +22,9 @@ class LinkShortenerApiService
 	public function addParameters($url, $params = array())
 	{
 		$retryLimit = 3;
-		$retryCount = 0;
+		$retryCount = 1;
 
-		do {
+		while($retryCount <= $retryLimit) {
 			try {
 				return $this->postEncodeUrl($url, $params);
 			} catch (Exception $e) {
@@ -32,11 +32,13 @@ class LinkShortenerApiService
 				sleep(1);
 				if($retryCount === $retryLimit) {
 					$error = $e->getResponse();
-					echo "Unable to add parameters to the link. Server reseponse: ".$error;
+					echo "Unable to add parameters to the link. Server response: ".$error;
 				}
 				continue;
 			}
-		} while($retryCount < $retryLimit);
+		}
+
+		return "";
 	}
 
 	private function postEncodeUrl($url, $params)

--- a/lib/LinkShortenerApiService.php
+++ b/lib/LinkShortenerApiService.php
@@ -32,5 +32,5 @@ class LinkShortenerApiService
             $error = $e->getResponse();
             echo "Unable to add parameters to the link. Server reseponse: ".$error;
         }
-	}
+    }
 }

--- a/lib/LinkShortenerApiService.php
+++ b/lib/LinkShortenerApiService.php
@@ -21,11 +21,16 @@ class LinkShortenerApiService
 
 	public function addParameters($url, $params = array())
 	{
-		$response = $this->client->post('/encode', [
-			'query' => $params,
-			'json' => [
-				'url' => $url
-			]]);
-		return "" . $response->getBody();
+        try {
+            $response = $this->client->post('/encode', [
+                'query' => $params,
+                'json' => [
+                    'url' => $url
+                ]]);
+            return "" . $response->getBody();
+        }catch(\Exception $e) {
+            $error = $e->getResponse();
+            echo "Unable to add parameters to the link. Server reseponse: ".$error;
+        }
 	}
 }

--- a/lib/LinkShortenerApiService.php
+++ b/lib/LinkShortenerApiService.php
@@ -10,27 +10,27 @@ use GuzzleHttp\Exception\ClientException;
 
 class LinkShortenerApiService
 {
-    private $client;
+	private $client;
 
-    public function __construct()
-    {
-        $this->client = new Client([
-            'base_uri' => 'https://zapl.ac',
-        ]);
-    }
+	public function __construct()
+	{
+		$this->client = new Client([
+			'base_uri' => 'https://zapl.ac',
+		]);
+	}
 
-    public function addParameters($url, $params = array())
-    {
-        try {
-            $response = $this->client->post('/encode', [
-                'query' => $params,
-                'json' => [
-                    'url' => $url
-                ]]);
-            return "" . $response->getBody();
-        }catch(\Exception $e) {
-            $error = $e->getResponse();
-            echo "Unable to add parameters to the link. Server reseponse: ".$error;
-        }
-    }
+	public function addParameters($url, $params = array())
+	{
+		try {
+			$response = $this->client->post('/encode', [
+				'query' => $params,
+				'json' => [
+					'url' => $url
+				]]);
+			return "" . $response->getBody();
+		}catch(\Exception $e) {
+			$error = $e->getResponse();
+			echo "Unable to add parameters to the link. Server reseponse: ".$error;
+		}
+	}
 }

--- a/lib/LinkShortenerApiService.php
+++ b/lib/LinkShortenerApiService.php
@@ -10,17 +10,17 @@ use GuzzleHttp\Exception\ClientException;
 
 class LinkShortenerApiService
 {
-	private $client;
+    private $client;
 
-	public function __construct()
-	{
-		$this->client = new Client([
-			'base_uri' => 'https://zapl.ac',
-		]);
-	}
+    public function __construct()
+    {
+        $this->client = new Client([
+            'base_uri' => 'https://zapl.ac',
+        ]);
+    }
 
-	public function addParameters($url, $params = array())
-	{
+    public function addParameters($url, $params = array())
+    {
         try {
             $response = $this->client->post('/encode', [
                 'query' => $params,


### PR DESCRIPTION
Errory w przypadku błędów skracacza - w momencie dodawania tagów do linku.

`PHP Fatal error: Uncaught GuzzleHttp\Exception\ServerException: Server
error: `POST https://zapl.ac/encode?utm_medium=email&type=balance`
resulted in a `522 ` response in
/var/www/html/lms/vendor/guzzlehttp/guzzle/src/Exception/RequestException.php:113
Stack trace:
#0 /var/www/html/lms/vendor/guzzlehttp/guzzle/src/Middleware.php(65):
GuzzleHttp\Exception\RequestException::create()`