### PR TITLE
BILLTECH: bugfix: fixed php warnings (php >= 8.0)

### DIFF
--- a/handlers/BillTechLinkInsertHandler.php
+++ b/handlers/BillTechLinkInsertHandler.php
@@ -74,9 +74,9 @@ class BillTechLinkInsertHandler
 		$link = self::getPaymentLink('balance', $customerid, ['utm_medium' => 'email']);
 
 		$phone = '';
-		if($hook_data['customer']['phone'] && $hook_data['customer']['phone'] != '') {
+		if (isset($hook_data['customer']['phone']) && $hook_data['customer']['phone'] != '') {
 			$phone = $hook_data['customer']['phone'];
-		}else if($hook_data['customer']['phones'] && $hook_data['customer']['phones'] != '') {
+		} elseif (isset($hook_data['customer']['phones']) && $hook_data['customer']['phones'] != '') {
 			$phone = $hook_data['customer']['phones'];
 		}
 


### PR DESCRIPTION
Potrzebne `isset()` do sprawdzenia czy zmienne istnieją - inaczej na PHP >= 8.0 mam ostrzeżenia:
```
PHP Warning:  Undefined array key "phones" in /var/www/html/lms/plugins/BillTech/handlers/BillTechLinkInsertHandler.php on line 79
PHP Warning:  Undefined array key "phones" in /var/www/html/lms/plugins/BillTech/handlers/BillTechLinkInsertHandler.php on line 79
PHP Warning:  Undefined array key "phones" in /var/www/html/lms/plugins/BillTech/handlers/BillTechLinkInsertHandler.php on line 79
```