### PR TITLE
BILLTECH: bugfix: fixed php warnings

### DIFF
--- a/BillTechPaymentsUpdater.php
+++ b/BillTechPaymentsUpdater.php
@@ -119,7 +119,8 @@ class BillTechPaymentsUpdater
 					'userid' => null,
 					'customerid' => $payment->userId,
 					'comment' => BillTech::CASH_COMMENT.' za: '.$payment->title,
-					'time' => $payment->paidAt
+					'time' => $payment->paidAt,
+					'currency' => 'PLN',
 				);
 
 				$cashid = $this->addBalanceReturnCashIdOrFalse($addbalance);

--- a/handlers/BillTechLinkInsertHandler.php
+++ b/handlers/BillTechLinkInsertHandler.php
@@ -74,9 +74,9 @@ class BillTechLinkInsertHandler
 		$link = self::getPaymentLink('balance', $customerid, ['utm_medium' => 'email']);
 
 		$phone = '';
-		if($hook_data['customer']['phone'] && $hook_data['customer']['phone'] != '') {
+		if (isset($hook_data['customer']['phone']) && $hook_data['customer']['phone'] != '') {
 			$phone = $hook_data['customer']['phone'];
-		}else if($hook_data['customer']['phones'] && $hook_data['customer']['phones'] != '') {
+		} elseif (isset($hook_data['customer']['phones']) && $hook_data['customer']['phones'] != '') {
 			$phone = $hook_data['customer']['phones'];
 		}
 


### PR DESCRIPTION
Missed 'currency' element in parameters passed to LMS::AddBalance() generate php warnings:
```
19/05/2023 15:38:01 PHP Warning: Undefined array key "currency" in /var/www/html/lms/lib/LMSManagers/LMSFinanceManager.php on line 3635
```
Please merge this fix ASAP.