### PR TITLE
BILLTECH: improvement/bugfix: use 'format' parameter passed to 'notif…

### DIFF
--- a/handlers/BillTechLinkInsertHandler.php
+++ b/handlers/BillTechLinkInsertHandler.php
@@ -70,6 +70,7 @@ class BillTechLinkInsertHandler
 	public function notifyCustomerDataParse(array $hook_data = array())
 	{
 		$data = $hook_data['data'];
+		$format = isset($hook_data['format']) && $hook_data['format'] == 'html' ? 'html' : 'text';
 		$customerid = $hook_data['customer']['id'];
 		$link = self::getPaymentLink('balance', $customerid, ['utm_medium' => 'email']);
 
@@ -86,7 +87,7 @@ class BillTechLinkInsertHandler
 		}
 
 		$hook_data['data'] = preg_replace('/%billtech_balance_btn/',
-			$this->createEmailButton('html', $link), $data);
+			$this->createEmailButton($format, $link), $data);
 
 		return $hook_data;
 	}


### PR DESCRIPTION
Poprawka/usprawnienie we wtyczce związane ze zmianą w gałęzi rozwojowej LMS:
https://github.com/chilek/lms/commit/983c3ba695fbfdece07bacb1e94c05b40ce6cdc8
która została również przeniesiona do obydwu gałęzi na ten moment wspieranych LMS+ (stable/27.x, stable-26/26.x).
Umożliwia rozróżnienej formatu wiadomości przy powiadomieniach generowanych ze skryptu bin/lms-notify.php. Wiadomo, że dla SMS-ów wstawianie kodu HTML z przyciskiem płatności nie ma sensu. Problem dyskutowany pierwotnie
na liście mailingowej LMS+ (lms-plus@lists.lms.org.pl).

Proszę o jak najszybszy możliwy merge tego PR-a.