### PR TITLE
Remove unused global $DB declarations in BillTechLinkInsertHandler

### DIFF
--- a/handlers/BillTechLinkInsertHandler.php
+++ b/handlers/BillTechLinkInsertHandler.php
@@ -20,7 +20,6 @@ class BillTechLinkInsertHandler
 
 	private function getPaymentLink($doc, $customerId, $params = array())
 	{
-		global $DB;
 		$linksManager = $this->getLinksManager();
 
 		if ($doc == 'balance') {
@@ -34,7 +33,6 @@ class BillTechLinkInsertHandler
 
 	private function getShortPaymentLink($doc, $customerId, $params = array())
 	{
-		global $DB;
 		$linksManager = $this->getLinksManager();
 
 		if ($doc == 'balance') {
@@ -48,7 +46,6 @@ class BillTechLinkInsertHandler
 
 	public function addButtonToInvoiceEmail(array $hook_data = array())
 	{
-		global $DB;
 		$linksManager = $this->getLinksManager();
 
 		$linksManager->updateCustomerBalance($hook_data['doc']['customerid']);


### PR DESCRIPTION
Removes three unused `global $DB;` declarations in `handlers/BillTechLinkInsertHandler.php` (`getPaymentLink`, `getShortPaymentLink`, `addButtonToInvoiceEmail`) — none of these methods reference `$DB`.

Checked all other `global $DB` occurrences in the repo — the remaining ones are actually used.

Addresses point 2 of the reported issue about the `invoice_email_before_send` hook.