### PR TITLE
Scope customer info backfill in updateCustomerBalance to a single customer

### DIFF
--- a/lib/BillTechLinksManager.php
+++ b/lib/BillTechLinksManager.php
@@ -106,7 +106,7 @@ class BillTechLinksManager
 	public function updateCustomerBalance($customerId)
 	{
 		global $DB;
-		$this->addMissingCustomerInfo();
+		$this->addMissingCustomerInfo($customerId);
 
 		$customerInfo = $DB->GetRow("select bci.*, max(c.id) as new_last_cash_id from billtech_customer_info bci 
 										left join cash c on c.customerid = bci.customer_id
@@ -387,14 +387,15 @@ class BillTechLinksManager
 		return $actions;
 	}
 
-	private function addMissingCustomerInfo()
+	private function addMissingCustomerInfo($customerId = null)
 	{
 		global $DB;
 		$DB->Execute("insert into billtech_customer_info (customer_id, last_cash_id)
 					select cu.id, 0
 					from customers cu
 							 left join billtech_customer_info bci on bci.customer_id = cu.id
-					where bci.customer_id is null;");
+					where bci.customer_id is null" . ($customerId ? " and cu.id = ?" : "") . ";",
+			$customerId ? array($customerId) : null);
 	}
 
 	/**


### PR DESCRIPTION
`updateCustomerBalance()` is called from hot paths (`invoice_email_before_send` hook for every emailed invoice, customer panel finances view), but it ran `addMissingCustomerInfo()` — a full-table `INSERT ... SELECT` over all customers — on every call.

`addMissingCustomerInfo()` now accepts an optional `$customerId` and `updateCustomerBalance()` passes it, so the backfill only ensures the `billtech_customer_info` row for the customer being processed (with `last_cash_id = 0`, so a new customer is still picked up immediately). The cron path (`updateForAll()`) keeps calling it without arguments, preserving the global backfill there. Semantics are unchanged.

Addresses point 3 of the reported issue about the `invoice_email_before_send` hook.