### PR TITLE
Fix PHP 8 warnings in message hook, link URL building and payment list

### DIFF
--- a/handlers/BillTechLinkInsertHandler.php
+++ b/handlers/BillTechLinkInsertHandler.php
@@ -94,10 +94,10 @@ class BillTechLinkInsertHandler
 
 	public function messageaddCustomerDataParse(array $hook_data = array())
 	{
-		$customerid = $hook_data['data']['id'];
+		$customerid = $hook_data['data']['id'] ?? null;
 		$appendCustomerInfoEnabled = ConfigHelper::getConfig('billtech.append_customer_info', true);
 
-		$amount = sprintf('%01.2f', -$hook_data['data']['balance']);
+		$amount = sprintf('%01.2f', -($hook_data['data']['balance'] ?? 0));
 		$btnPatterns = ['/%billtech_balance_btn/', '/'.$amount.'illtech_balance_btn/'];
 
 		if(isset($hook_data['data']['phone'])) {

--- a/lib/BillTechLinkApiService.php
+++ b/lib/BillTechLinkApiService.php
@@ -58,9 +58,9 @@ class BillTechLinkApiService
 		foreach ($json as $idx => $link) {
 			$linkData = $linkDataList[$idx];
 			$link->link = $link->link .
-				'?email=' . urlencode($linkData['email']) .
-				'&name=' . urlencode(self::getNameOrSurname($linkData['name'])) .
-				'&surname=' . urlencode(self::getNameOrSurname($linkData['lastname'])) .
+				'?email=' . urlencode((string) $linkData['email']) .
+				'&name=' . urlencode((string) self::getNameOrSurname($linkData['name'])) .
+				'&surname=' . urlencode((string) self::getNameOrSurname($linkData['lastname'])) .
 				'&utm_content=' . urlencode($isp_id) .
 				'&utm_source=isp';
 			array_push($result, $link);
@@ -221,7 +221,7 @@ class BillTechLinkApiService
 
 	private static function getNameOrSurname($nameOrSurname)
 	{
-		return substr(preg_replace("/[^ A-Za-z0-9\-,.\x{00c0}-\x{02c0}]/u", " ", $nameOrSurname), 0, 100) ?: null;
+		return substr(preg_replace("/[^ A-Za-z0-9\-,.\x{00c0}-\x{02c0}]/u", " ", (string) $nameOrSurname), 0, 100) ?: null;
 	}
 
 	private static function getRecipientName($divisionName)

--- a/modules/billtechpaymentlist.php
+++ b/modules/billtechpaymentlist.php
@@ -94,6 +94,9 @@ function GetBillTtechPaymentsList($order, $search = NULL, $cat = NULL, $hideclos
 		$result['page'] = $page > 0 ? $page : ceil($id / $pagelimit);
 	}
 
+	if (!isset($result['page']))
+		$result['page'] = 1;
+
 	$result['order'] = $order;
 	$result['direction'] = $direction;
 


### PR DESCRIPTION
Fixes three PHP 8 warnings/deprecations showing up in production logs:

- **`BillTechLinkInsertHandler::messageaddCustomerDataParse`** — the `messageadd_variable_parser` hook is also executed by LMS for messages not tied to a customer (e.g. SMS to an arbitrary number), where `data` has no `id`/`balance` keys. Reads are now null-safe; behavior is unchanged (no customer → no link → placeholders stripped, as before).
- **`BillTechLinkApiService`** — `getNameOrSurname()` intentionally returns `null` for empty values, which was passed to `urlencode()` (deprecated on PHP 8.1+). Values are cast to string at the URL-building site; `getNameOrSurname()` also casts its input so a `null` name/lastname doesn't trip `preg_replace()`. The `?: null` return is kept, so the API request payload is unaffected.
- **`billtechpaymentlist.php`** — `GetBillTtechPaymentsList()` only set the `page` key when the query returned a result; it now always sets it, so the caller no longer hits "Undefined array key \"page\"".
