### PR TITLE
Fix transaction handling in performActions (dangling transaction, stale GetErrors)

### DIFF
--- a/lib/BillTechLinksManager.php
+++ b/lib/BillTechLinksManager.php
@@ -262,31 +262,16 @@ class BillTechLinksManager
 	 */
 	public function performActions($actions)
 	{
-		global $DB;
 		$addBatches = array_chunk($actions['add'], $this->batchSize);
 		$errorCount = 0;
 		foreach ($addBatches as $idx => $links) {
 			if ($this->verbose) {
 				echo "Adding batch " . ($idx + 1) . " of " . count($addBatches) . "\n";
 			}
-			try {
-				$DB->BeginTrans();
+			if (!$this->executeInTransaction(function () use ($links) {
 				$this->addPayments($links);
-				if (!$DB->GetErrors()) {
-					$DB->CommitTrans();
-				} else {
-					foreach ($DB->GetErrors() as $error) {
-						echo $error['query'] . PHP_EOL;
-						echo $error['error'] . PHP_EOL;
-					}
-					$errorCount++;
-					$DB->RollbackTrans();
-				}
-			} catch (Exception $e) {
+			})) {
 				$errorCount++;
-				if (ConfigHelper::checkConfig("billtech.debug")) {
-					echo $e->getMessage();
-				}
 			}
 		}
 
@@ -294,24 +279,10 @@ class BillTechLinksManager
 			if ($this->verbose) {
 				echo "Updating link " . ($idx + 1) . " of " . count($actions['update']) . "\n";
 			}
-			try {
-				$DB->BeginTrans();
+			if (!$this->executeInTransaction(function () use ($link) {
 				$this->updatePaymentAmount($link);
-				if (!$DB->GetErrors()) {
-					$DB->CommitTrans();
-				} else {
-					foreach ($DB->GetErrors() as $error) {
-						echo $error['query'] . PHP_EOL;
-						echo $error['error'] . PHP_EOL;
-					}
-					$errorCount++;
-					$DB->RollbackTrans();
-				}
-			} catch (Exception $e) {
+			})) {
 				$errorCount++;
-				if (ConfigHelper::checkConfig("billtech.debug")) {
-					echo $e->getMessage();
-				}
 			}
 		}
 
@@ -319,28 +290,40 @@ class BillTechLinksManager
 			if ($this->verbose) {
 				echo "Closing link " . ($idx + 1) . " of " . count($actions['close']) . "\n";
 			}
-			try {
-				$DB->BeginTrans();
+			if (!$this->executeInTransaction(function () use ($link) {
 				$this->closePayment($link);
-				if (!$DB->GetErrors()) {
-					$DB->CommitTrans();
-				} else {
-					foreach ($DB->GetErrors() as $error) {
-						echo $error['query'] . PHP_EOL;
-						echo $error['error'] . PHP_EOL;
-					}
-					$errorCount++;
-					$DB->RollbackTrans();
-				}
-			} catch (Exception $e) {
+			})) {
 				$errorCount++;
-				if ($this->verbose) {
-					echo $e->getMessage();
-				}
 			}
 		}
 
 		return $errorCount == 0;
+	}
+
+	private function executeInTransaction($callback)
+	{
+		global $DB;
+		$errorCountBefore = count($DB->GetErrors());
+		try {
+			$DB->BeginTrans();
+			$callback();
+			$errors = array_slice($DB->GetErrors(), $errorCountBefore);
+			if (!$errors) {
+				$DB->CommitTrans();
+				return true;
+			}
+			foreach ($errors as $error) {
+				echo $error['query'] . PHP_EOL;
+				echo $error['error'] . PHP_EOL;
+			}
+			$DB->RollbackTrans();
+		} catch (Exception $e) {
+			$DB->RollbackTrans();
+			if ($this->verbose || ConfigHelper::checkConfig("billtech.debug")) {
+				echo $e->getMessage();
+			}
+		}
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
Fixes two defects in `BillTechLinksManager::performActions()` transaction handling that are the root cause of #145 and the most likely cause of #132.

**1. Dangling transaction on exception (root cause of #145).** When `addPayments()`/`updatePaymentAmount()`/`closePayment()` threw (e.g. BillTech API unavailable), the `catch` block did not roll back — the transaction opened by `BeginTrans()` stayed open. `performActions` runs inside LMS hooks (`invoice_email_before_send`, customer panel), so everything LMS core did afterwards — including `PublishDocuments()`/`MarkDocumentsAsSent()` after a successful SMTP send — landed inside that open transaction and was lost on the next explicit `ROLLBACK` or when the process exited without commit. That is exactly the reported symptom: e-mails go out via SMTP, but sent/published flags get reverted. The LMS DB layer has no transaction nesting (`BeginTrans` is a bare `BEGIN`, `RollbackTrans` a bare `ROLLBACK`), so a leaked transaction silently swallows the caller's work. The `catch` now always rolls back.

**2. Success detection poisoned by accumulated errors (likely cause of #132).** `$DB->GetErrors()` returns errors accumulated for the whole connection lifetime and is never cleared. After a single unrelated SQL error anywhere earlier in the process, every subsequent batch took the error branch and rolled back — permanently. For link closing this is particularly bad: the BillTech API cancel had already been sent, but the local `DELETE` was rolled back, leaving a stale `billtech_payment_links` row. That stale row makes `getBalanceLink()` keep returning a link, so an overpaid/zero-balance customer still gets the "Opłać saldo" button (#132) — pointing at a link already cancelled on the BillTech side. The check now looks only at errors reported during the current callback (delta against the count captured before `BeginTrans`).

The three copy-pasted transaction blocks are folded into one `executeInTransaction()` helper so the semantics live in a single place. Behavior otherwise unchanged: per-item isolation, same verbose output, `performActions` still returns `false` on any error so `last_cash_id` is not advanced and the sync retries.

Fixes #145
Refs #132
